### PR TITLE
Added minimum margin to Day Component and Left menu in App.vue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,7 @@
 
     <div class="flex">
 
-      <div class="mr-16" style="width:250px !important;">
+      <div class="mr-16" style="width:250px !important; min-width: 250px;">
 
         <off-days />
 

--- a/src/components/Day.vue
+++ b/src/components/Day.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex-1 mx-1s p-4">
+    <div class="flex-1 mx-1s p-4" style="min-width: 208px;">
         <div class="mb-1">{{ name }}</div>
         <div class="text-xs text-gray-600 mb-4">
         🕒 {{ workingHours - remaining }} / {{ workingHours }}


### PR DESCRIPTION
Why:
- left menu becomes cramped if project names are too long and the days are full.

Done:
- Added minimum width of 208px on days
- Added minimum width of 250px on left menu

issue #10 